### PR TITLE
Require aws php sdk 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,11 @@
     ],
     "require": {
         "php": "^7.3|^7.4|^8.0",
+        "aws/aws-sdk-php": "^3.178",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "illuminate/support": "5.*|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "aws/aws-sdk-php": "^3.0",
         "orchestra/testbench": "^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^5.0|^6.0|^8.0|^9.3"
     },

--- a/src/Converters/PollyConverter.php
+++ b/src/Converters/PollyConverter.php
@@ -18,7 +18,7 @@ class PollyConverter implements Converter
     /**
      * Client instance of Polly.
      *
-     * @var \Aws\Polly\PollyClient
+     * @var PollyClient
      */
     protected $client;
 
@@ -163,11 +163,11 @@ class PollyConverter implements Converter
     /**
      * Get the text type.
      *
-     * @return void
+     * @return string
      */
     protected function textType()
     {
-        $default = config('tts.text_type', 'text');
+        $default = (string) config('tts.text_type', 'text');
 
         return $this->textType ?? $default;
     }
@@ -185,7 +185,7 @@ class PollyConverter implements Converter
     /**
      * Get the audio format.
      *
-     * @param  array $options
+     * @param array $options
      * @return string
      */
     protected function format($options)
@@ -198,7 +198,7 @@ class PollyConverter implements Converter
     /**
      * Get the content of the result from AWS Polly.
      *
-     * @param mixed $result
+     * @param Result $result
      * @return mixed
      */
     protected function getResultContent($result)


### PR DESCRIPTION
Instead of requiring the `aws/aws-sdk-php` package after installing this package this will already require the `aws/aws-sdk-php` in this package. 